### PR TITLE
Added default study variable name "undefined"

### DIFF
--- a/specification_document-developments/1_1-Metabolomics-Draft/mzTab_format_specification_1_1-M_draft.adoc
+++ b/specification_document-developments/1_1-Metabolomics-Draft/mzTab_format_specification_1_1-M_draft.adoc
@@ -984,7 +984,7 @@ MTD assay[1]-ms_run_ref ms_run[1]
 
 [cols=",",]
 |================================================================================================================================================================================================================================================================================================
-|*Description:* |A name for each study variable (experimental condition or factor), to serve as a list of the study variables that MUST be reported in the following tables. For software that does not capture study variables, a single study variable MUST be reported, linking to all assays.
+|*Description:* |A name for each study variable (experimental condition or factor), to serve as a list of the study variables that MUST be reported in the following tables. For software that does not capture study variables, a single study variable MUST be reported, linking to all assays. This single study variable MUST have the identifier “undefined“.
 |*Type:* |String
 |*Mandatory* |True
 |*Example:* a|


### PR DESCRIPTION
Since study variable is mandatory, we need a sensible default in case the reporting software has no knowledge of the study variable.