### PR TITLE
Added orcid as new field for contact.

### DIFF
--- a/specification_document-releases/2_0-Metabolomics-Release/mzTab_format_specification_2_0-M_release.adoc
+++ b/specification_document-releases/2_0-Metabolomics-Release/mzTab_format_specification_2_0-M_release.adoc
@@ -20,7 +20,7 @@ endif::[]
 
 :commit-hash: UNDEFINED
 :build-date: UNDEFINED
-:document-version: 2.0.0-Final March 2019 (RELEASE)
+:document-version: 2.0.1-Draft December 2022 (DRAFT)
 
 //disable section numbering
 :!sectnums:
@@ -677,6 +677,25 @@ MTD contact[2]-affiliation Cambridge University, UK
 MTD contact[1]-email watson@cam.ac.uk
 …
 MTD contact[2]-email crick@cam.ac.uk
+....
+|===================================================
+
+[[contact1-n-orcid]]
+==== contact[1-n]-orcid
+
+[cols=",",]
+|===================================================
+|*Description* |The contact's orcid id, without https prefix.
+|*Type* |Regex
+....
+[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]{1}
+....
+|*Mandatory* |False
+|*Example* a|
+....
+…
+MTD contact[2]-email crick@cam.ac.uk
+MTD contact[2]-orcid	0000-0002-1825-0097
 ....
 |===================================================
 


### PR DESCRIPTION
Orcid is a practical identifier id for researchers. Adding orcid as an optional field for contacts will make it easier to (re)find contacts who have changed affiliations and may no longer be reachable via the original e-mail.