### PR TITLE
Fix regex in semantic version specification

### DIFF
--- a/specification_document-releases/2_0-Metabolomics-Release/mzTab_format_specification_2_0-M_release.adoc
+++ b/specification_document-releases/2_0-Metabolomics-Release/mzTab_format_specification_2_0-M_release.adoc
@@ -458,7 +458,7 @@ Regular expressions (*Regex*) follow the Perl regular expression syntax with min
 |*Description* |The version of the mzTab file. The suffix MUST be "-M" for mzTab for metabolomics (mzTab-M).
 |*Type* a|Regex
 ....
-\d{2}\.\d{0}\.\d{0}-M
+(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-M
 ....
 |*Mandatory* |True
 |*Example* a|


### PR DESCRIPTION
The previous regex can't match `2.0.0-M` but only `02..-M`.
This updated regex will correctly match and follows semver conventions as specified under semver.org.
The regex here is also taken and adapted from the one specified at the bottom of the semver homepage.