### PR TITLE
Fixed version number of MTBLS263 example

### DIFF
--- a/examples/2_0-Metabolomics_Release/MTBLS263.mztab
+++ b/examples/2_0-Metabolomics_Release/MTBLS263.mztab
@@ -1,4 +1,4 @@
-MTD	mzTab-version	2.2.0-M																						
+MTD	mzTab-version	2.0.0-M																						
 MTD	mzTab-ID	JetBike Test																						
 MTD	software[1]	[MS,MS:1002879,Progenesis QI,2.4.6505.48857]																						
 MTD	ms_run[1]-location	file:///D:/Data%20Sets/Metabolomics/MTBLS263/3injections_inj1_POS.mzML																						


### PR DESCRIPTION
Corrects the too high minor number in the example file. 
The version still conforms to the regular expression for the version string, so did not complain in this case.